### PR TITLE
Force a numeric keypad on platforms with a dynamic keyboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
           <label class="sr-only" for="addFiveDieRollWord">Add Two or Five Die Roll</label>
           <div class="input-group">
             <div class="input-group-addon">#</div>
-            <input type="number" class="form-control" id="addFiveDieRollWord" placeholder="+ 2x or 5x die roll" maxlength="5" pattern="^[1-6]{2,5}$" autocomplete="off">
+            <input type="tel" class="form-control" id="addFiveDieRollWord" placeholder="+ 2x or 5x die roll" maxlength="5" pattern="^[1-6]{2,5}$" autocomplete="off">
           </div>
           <span class="help-block with-errors"></span>
         </div>

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
           <label class="sr-only" for="addFiveDieRollWord">Add Two or Five Die Roll</label>
           <div class="input-group">
             <div class="input-group-addon">#</div>
-            <input type="text" class="form-control" id="addFiveDieRollWord" placeholder="+ 2x or 5x die roll" maxlength="5" pattern="^[1-6]{2,5}$">
+            <input type="number" class="form-control" id="addFiveDieRollWord" placeholder="+ 2x or 5x die roll" maxlength="5" pattern="^[1-6]{2,5}$" autocomplete="off">
           </div>
           <span class="help-block with-errors"></span>
         </div>


### PR DESCRIPTION
The key benefit of this change is it prevents inputting anything but a number
into the input field. It also brings up a numeric keypad on mobile devices,
making it easier to input dice values.

Also explicitly turn off autocomplete as you don't want to accidentally select
a previous role value.

Spec can be found at https://www.w3.org/TR/html-markup/input.number.html.