### PR TITLE
Use autofocus

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
           <div class="input-group">
             <div class="input-group-addon">#</div>
             <!-- hack : use tel as the input type instead of text to force numeric keypad on mobile devices -->
-            <input type="tel" class="form-control" id="addFiveDieRollWord" placeholder="+ 2x or 5x die roll" maxlength="5" pattern="^[1-6]{2,5}$" autocomplete="off">
+            <input type="tel" class="form-control" id="addFiveDieRollWord" placeholder="+ 2x or 5x die roll" maxlength="5" pattern="^[1-6]{2,5}$" autocomplete="off" autofocus>
           </div>
           <span class="help-block with-errors"></span>
         </div>


### PR DESCRIPTION
It's a [widely supported](http://caniuse.com/#feat=autofocus) [feature of HTML5](https://www.w3.org/TR/html-markup/input.text.html#input.text.attrs.autofocus) that causes the page to automatically select the input field on load. It doesn't help too much on mobile as it doesn't bring up the keyboard automatically to prevent hiding page content, but on the desktop it's nice as it means once the page is loaded you can literally start typing and have it  be in the input box without  having to click on it first.