### PR TITLE
Update to add IE11 msCrypto support

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -25,7 +25,8 @@ function addCommas (nStr) {
 function getRandomByteArray (numElements) {
   numElements = parseInt(numElements, 10)
   var randomBytes = new Uint32Array(numElements)
-  window.crypto.getRandomValues(randomBytes)
+  var objCrypto = window.crypto || window.msCrypto;  
+  objCrypto.getRandomValues(randomBytes)
   return randomBytes
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -23,11 +23,11 @@ function addCommas (nStr) {
 
 // Security Function. Returns the CSPRNG bytes.
 function getRandomByteArray (numElements) {
-  numElements = parseInt(numElements, 10)
-  var randomBytes = new Uint32Array(numElements)
-  var objCrypto = window.crypto || window.msCrypto;  
-  objCrypto.getRandomValues(randomBytes)
-  return randomBytes
+  numElements = parseInt(numElements, 10);
+  var randomBytes = new Uint32Array(numElements);
+  var objCrypto = window.crypto || window.msCrypto;
+  objCrypto.getRandomValues(randomBytes);
+  return randomBytes;
 }
 
 // Use a cryptographically strong random number generator


### PR DESCRIPTION
IE11's WebCrypto implementation is prefixed, the code below falls back to msCrypto if crypto is not available.   Fallback to math.random() for creaky browsers that don't deserve it is possible.