### PR TITLE
Correcting typo with integrity attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -817,7 +817,7 @@
     <script
       async
       src="lists/czech-min.js"
-      integryty="sha384-tFySTckw13k8sBNmzVLc/QOIh92GTJmHRMDYjnjR5c8XwXq7djvlp+fE8DqUKhNb"
+      integrity="sha384-tFySTckw13k8sBNmzVLc/QOIh92GTJmHRMDYjnjR5c8XwXq7djvlp+fE8DqUKhNb"
       crossorigin="anonymous"
     ></script>
     <script
@@ -901,7 +901,7 @@
     <script
       async
       src="lists/russian-min.js"
-      integryty="sha384-hQRKR3ReKFidL1Zkprmbumo3c/u7DIkrWXHKe31uPEv2GyVseFnPWkIAfXYj7T+P"
+      integrity="sha384-hQRKR3ReKFidL1Zkprmbumo3c/u7DIkrWXHKe31uPEv2GyVseFnPWkIAfXYj7T+P"
       crossorigin="anonymous"
     ></script>
     <script


### PR DESCRIPTION
Hey !

There is a typo in two places for the key to the hash of lists, in the `integrity` attribute of the <script> tag. This corrects it.